### PR TITLE
ID3DBuffer와 SRV를 경량패턴으로 경량화시킴 성과 : 메모리 446MB  =>  100 MB

### DIFF
--- a/Digimon_Game_Portfolio/Actors/Attacker.h
+++ b/Digimon_Game_Portfolio/Actors/Attacker.h
@@ -30,6 +30,7 @@ public:
 	void CreateShaderAndBuffer(wstring imgfile, vector<D3DXVECTOR4> uvs, Sprites_Info info, int level);
 
 	void CreateAnimation(); // Animation객체 
+	void UpdateSrvAndBuffer();
 
 
 	virtual void FindLookAtTarget() = 0;
@@ -104,9 +105,12 @@ protected:
 	ID3D11Buffer* vertexBuffer;
 
 	Vertex vertices[6];
-	vector<vector<ID3D11ShaderResourceView*>> srv_vec;
+	//vector<vector<ID3D11ShaderResourceView*>> srv_vec;
+	ID3D11ShaderResourceView* m_srv;
 	vector<vector<ID3D11Buffer*>> buffer_vec;
 
+
+	//
 	float indexing = 0.f;
 	int idx = indexing;
 
@@ -120,4 +124,7 @@ protected:
 	protected:
 		vector<unique_ptr<class Animation>> animations;
 		FORCEINLINE void Set_Mode(UINT mode) { State = mode; animations[State]->Start(); } // 자동으로 애니메이션 호출
+
+
+	
 };

--- a/Digimon_Game_Portfolio/Animation.cpp
+++ b/Digimon_Game_Portfolio/Animation.cpp
@@ -29,17 +29,29 @@ Animation::Animation(Sprite_Info info, PlayMode type)
 
 }
 
-Animation::Animation(Shader* shader, vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode)
-	:m_Shader(shader),m_srv_vec(srv_vec), m_buffer_vec(buffer_vec),mode(mode), play_rate(9.f)
+//Animation::Animation(Shader* shader, vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode)
+//	:m_Shader(shader),m_srv_vec(srv_vec), m_buffer_vec(buffer_vec),mode(mode), play_rate(9.f)
+//{
+//	
+//}
+Animation::Animation(Shader* shader, ID3D11ShaderResourceView* srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode)
+	: m_Shader(shader), m_srv(srv_vec), m_buffer_vec(buffer_vec), mode(mode), play_rate(9.f)
 {
-	
+
 }
 
-void Animation::UpdateSrvAndBuffer(vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec)
+void Animation::UpdateSrvAndBuffer(ID3D11ShaderResourceView* srv, vector<ID3D11Buffer*> buffer_vec)
 {
-	m_srv_vec = srv_vec;
+	m_srv = srv;
 	m_buffer_vec = buffer_vec;
 }
+
+
+//void Animation::UpdateSrvAndBuffer(vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec)
+//{
+//	m_srv_vec = srv_vec;
+//	m_buffer_vec = buffer_vec;
+//}
 
 void Animation::Update()
 {
@@ -51,18 +63,18 @@ void Animation::Update()
 	switch (mode)
 	{
 	case PlayMode::Loop:
-		if (index >= m_srv_vec.size())
+		if (index >= m_buffer_vec.size())
 		{
 			index = 0;
 			playtime = 0.f;
 		}
 		break;
 	case PlayMode::End:
-		if (index >= m_srv_vec.size())
+		if (index >= m_buffer_vec.size())
 		{
 			if (Owner == nullptr)// Owner가 없는경우
 			{
-				index = m_srv_vec.size() - 1; //마지막 상태 유지
+				index = m_buffer_vec.size() - 1; //마지막 상태 유지
 				bvisible = false;
 			}
 			else // Owner가 있는경우
@@ -78,9 +90,9 @@ void Animation::Update()
 		break;
 	case PlayMode::End_Stop:
 		
-		if (index >= m_srv_vec.size())
+		if (index >= m_buffer_vec.size())
 		{
-			index = m_srv_vec.size() - 1;
+			index = m_buffer_vec.size() - 1;
 
 			if (enemy != nullptr)
 			{
@@ -100,13 +112,13 @@ void Animation::Render()
 {
 	CheckFalse(bvisible);
 
-	if (index >= m_srv_vec.size())
-		index = m_srv_vec.size() - 1;
+	if (index >= m_buffer_vec.size())
+		index = m_buffer_vec.size() - 1;
 
 	UINT stride = sizeof(Vertex);
 	UINT offset = 0;
 
-	m_Shader->AsShaderResource("Map")->SetResource(m_srv_vec[index]);
+	m_Shader->AsShaderResource("Map")->SetResource(m_srv);
 
 	DeviceContext->IASetVertexBuffers(0, 1, &m_buffer_vec[index], &stride, &offset);
 	DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);

--- a/Digimon_Game_Portfolio/Animation.h
+++ b/Digimon_Game_Portfolio/Animation.h
@@ -39,13 +39,15 @@ private:
 
 	//  ∏Æ∆—≈‰∏µ
 public:
-	Animation(class Shader* shader, vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode = PlayMode::Loop);
-	void UpdateSrvAndBuffer(vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec);
+	//Animation(class Shader* shader, vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode = PlayMode::Loop);
+	Animation(class Shader* shader, ID3D11ShaderResourceView* srv_vec, vector<ID3D11Buffer*> buffer_vec, PlayMode mode = PlayMode::Loop);
+	//void UpdateSrvAndBuffer(vector<ID3D11ShaderResourceView*> srv_vec, vector<ID3D11Buffer*> buffer_vec);
+	void UpdateSrvAndBuffer(ID3D11ShaderResourceView* srv, vector<ID3D11Buffer*> buffer_vec);
 private:
 
 
 	class Shader* m_Shader =  nullptr;
-	vector<ID3D11ShaderResourceView*> m_srv_vec;
+	//vector<ID3D11ShaderResourceView*> m_srv_vec;
 	vector<ID3D11Buffer*> m_buffer_vec;
 protected:
 	vector<unique_ptr<class Animation>> animations;
@@ -54,6 +56,10 @@ protected:
 	D3DXVECTOR3 m_position = { 0,0,0 };
 	D3DXVECTOR3 m_rotator = { 0,0,0 };
 	D3DXVECTOR3 m_scale = { 1,1,1 };
+
+
+	//∏Æ∆—≈‰∏µ
 	
+	ID3D11ShaderResourceView* m_srv;
 };
 

--- a/Digimon_Game_Portfolio/Bullet.h
+++ b/Digimon_Game_Portfolio/Bullet.h
@@ -77,7 +77,7 @@ private:
 
 	class Shader* m_Shader;
 	vector<ID3D11Buffer*> buffer_vec;
-	vector<ID3D11ShaderResourceView*> srv_vec;
+	ID3D11ShaderResourceView* m_srv;
 	
 };
 
@@ -124,7 +124,8 @@ private:
 	static vector<Shader*> shader_vec;
 	static int shader_idx; // 배열로 순차탐색 구현
 
-	static vector<vector<ID3D11ShaderResourceView*>> srv_vec;
+	//static vector<vector<ID3D11ShaderResourceView*>> srv_vec;
+	static vector<ID3D11ShaderResourceView*> srv_vec;
 	static vector<vector<ID3D11Buffer*>> buffer_vec;
 
 	static vector<shared_ptr<Animation>> animations;

--- a/Digimon_Game_Portfolio/CastleGate.cpp
+++ b/Digimon_Game_Portfolio/CastleGate.cpp
@@ -16,7 +16,8 @@ CastleGate::CastleGate()
 
 	shader = make_unique<Shader>(Texture_Shader);
 	
-	make_unique<Sprite>(srv, buffer, Layer_Folder + L"Dungeon_01" + L"/" + Ground + to_wstring(0) + L".png");
+	srv = Sprite_Manager::Load(Layer_Folder + L"Dungeon_01" + L"/" + Ground + to_wstring(0) + L".png");
+	make_unique<Sprite>(buffer, Layer_Folder + L"Dungeon_01" + L"/" + Ground + to_wstring(0) + L".png");
 	// Ground
 	{
 		scale = D3DXVECTOR3(850, 800, 1);
@@ -43,7 +44,7 @@ void CastleGate::Render()
 	UINT offset = 0;
 
 	
-	shader->AsShaderResource("Map")->SetResource(srv[0]);
+	shader->AsShaderResource("Map")->SetResource(srv);
 
 	DeviceContext->IASetVertexBuffers(0, 1, &buffer[0], &stride, &offset);
 	DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);

--- a/Digimon_Game_Portfolio/CastleGate.h
+++ b/Digimon_Game_Portfolio/CastleGate.h
@@ -27,7 +27,7 @@ protected:
 	D3DXVECTOR3 rotator;
 
 	unique_ptr<class Shader> shader;
-	vector<ID3D11ShaderResourceView*> srv;
+	ID3D11ShaderResourceView* srv;
 	vector<ID3D11Buffer*> buffer;
 
 	class unique_ptr<class Sprite> Castle;

--- a/Digimon_Game_Portfolio/Decal.cpp
+++ b/Digimon_Game_Portfolio/Decal.cpp
@@ -5,37 +5,37 @@
 Decal::Decal()
 	:bVisible(false)
 {
-	sprite = make_unique<Sprite>(Decal_Folder + L"Circle.png", Decal_Shader);
+	//sprite = make_unique<Sprite>(Decal_Folder + L"Circle.png", Decal_Shader);
 }
 Decal::~Decal()
 {
 }
 void Decal::ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P)
 {
-	sprite->ViewProjection(V, P);
+	//sprite->ViewProjection(V, P);
 }
 
 void Decal::Update()
 {
-	CheckFalse(bVisible);
+	/*CheckFalse(bVisible);
 	D3DXVECTOR3 temp;
 	temp.x = Width * 0.5f;
 	temp.y = Height * 0.5f;
-	sprite->Position({ Mouse_Pos.x - temp.x, -(Mouse_Pos.y - temp.y), 0 });
+	sprite->Position({ Mouse_Pos.x - temp.x, -(Mouse_Pos.y - temp.y), 0 });*/
 }
 
 void Decal::Render()
 {
 	CheckFalse(bVisible);
-	sprite->Render();
+	//sprite->Render();
 }
 
 void Decal::Scale(D3DXVECTOR3 val)
 {
-	sprite->Scale(val);
+	//sprite->Scale(val);
 }
 
 void Decal::Position(D3DXVECTOR3 val)
 {
-	sprite->Position(val);
+	//sprite->Position(val);
 }

--- a/Digimon_Game_Portfolio/Digimon_Game.sln
+++ b/Digimon_Game_Portfolio/Digimon_Game.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.34031.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Digimon_Game", "Digimon_Game.vcxproj", "{74DDA932-B5B9-4831-A63C-C13663BE207C}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Shaders", "_Shaders", "{F361EFF1-2BD6-4506-BD5C-FBE166803DF6}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Shaders", "_Shaders", "{753F6CC6-833D-4466-9281-B7BC5CB0F6E1}"
 	ProjectSection(SolutionItems) = preProject
 		..\_Shaders\014_Bounding.fx = ..\_Shaders\014_Bounding.fx
 		..\_Shaders\01_Decal.fx = ..\_Shaders\01_Decal.fx

--- a/Digimon_Game_Portfolio/Map_Make/Map_Texture.cpp
+++ b/Digimon_Game_Portfolio/Map_Make/Map_Texture.cpp
@@ -23,8 +23,8 @@ void Map_Texture::Update()
 
 void Map_Texture::Render()
 {
-	Map->Render();
-	Swap_Map->Render();
+	//Map->Render();
+	//Swap_Map->Render();
 }
 
 void Map_Texture::Position(D3DXVECTOR3 val)

--- a/Digimon_Game_Portfolio/Object.cpp
+++ b/Digimon_Game_Portfolio/Object.cpp
@@ -11,6 +11,7 @@ void Object::Position(D3DXVECTOR3 vec)
 
 void Object::ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P)
 {
+	CheckNull(shader);
 	shader->AsMatrix("View")->SetMatrix(V);
 	shader->AsMatrix("Projection")->SetMatrix(P);
 }

--- a/Digimon_Game_Portfolio/Reward_Card.cpp
+++ b/Digimon_Game_Portfolio/Reward_Card.cpp
@@ -189,7 +189,7 @@ queue<shared_ptr<Reward_Card>>Card_Manager::q;
 
 //  ∏Æ∆—≈‰∏µ
 vector<Shader*> Card_Manager::shader_vec;
-vector<vector<ID3D11ShaderResourceView*>> Card_Manager::srv_vec;
+vector<ID3D11ShaderResourceView*> Card_Manager::srv_vec;
 vector<vector<ID3D11Buffer*>> Card_Manager::buffer_vec;
 
 vector<shared_ptr<Animation>> Card_Manager::animations;
@@ -208,9 +208,18 @@ void Card_Manager::Create(vector<wstring> data)
 	srv_vec.resize(cardTypeCnt);
 	buffer_vec.resize(cardTypeCnt);
 
-	for (int k = 0; k < data.size(); k++)
+	for (int k = 0; k < cardTypeCnt; k++)
 	{
-		make_shared<Sprite>(srv_vec[k], buffer_vec[k], data[k], Card_Shader);
+		srv_vec[k] = Sprite_Manager::Load(data[k]);
+		vector<vector<ID3D11Buffer*>> temp  = Sprite_Manager::LoadBufferVector(data[k]);
+		if (temp.size() == 0)
+		{
+			make_shared<Sprite>(buffer_vec[k], data[k], Card_Shader);
+			Sprite_Manager::StoreBuffer(data[k], buffer_vec[k]);
+		}
+		else
+			buffer_vec = temp;
+
 	}
 
 	shader_vec.reserve(CardPoolSize);

--- a/Digimon_Game_Portfolio/Reward_Card.h
+++ b/Digimon_Game_Portfolio/Reward_Card.h
@@ -59,7 +59,7 @@ public:
 	static vector<shared_ptr<class Animation>> animations;
 
 
-	static vector<vector<ID3D11ShaderResourceView*>> srv_vec;
+	static vector<ID3D11ShaderResourceView*> srv_vec;
 	static vector<vector<ID3D11Buffer*>> buffer_vec;
 
 	static shared_ptr<class Animation> Load(int& cardID);

--- a/Digimon_Game_Portfolio/Sprite.cpp
+++ b/Digimon_Game_Portfolio/Sprite.cpp
@@ -23,19 +23,16 @@ Sprite::Sprite(wstring imgFile, float start_X, float start_Y, float End_X, float
 
 }
 
-Sprite::Sprite(vector<ID3D11ShaderResourceView*>& ownerShader, vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, wstring shaderFile)
-	:Sprite(ownerShader, ownerbuffer, imgFile,0,0,1,1,shaderFile)
-{
 
+Sprite::Sprite(vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, wstring shaderFile)
+	:Sprite(ownerbuffer, imgFile, 0, 0, 1, 1, shaderFile)
+{
 }
 
-Sprite::Sprite(vector<ID3D11ShaderResourceView*>& owner_srv, vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, float start_X, float start_Y, float End_X, float End_Y,wstring shaderFile)
+Sprite::Sprite(vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, float start_X, float start_Y, float End_X, float End_Y, wstring shaderFile)
 {
-	
-	srv = Sprite_Manager::Load(imgFile);
-	owner_srv.push_back(srv);
-
 	Init_Sprite(imgFile, start_X, start_Y, End_X, End_Y);
+
 	CreateBuffer(imgFile, shaderFile);
 	ownerbuffer.push_back(vertexBuffer);
 	CreateBoundBuffer(Shaders + L"014_Bounding.fx");
@@ -226,63 +223,15 @@ void Sprite::CreateBuffer(wstring imgFile, wstring shaderFile)
 		assert(SUCCEEDED(hr));
 	}
 	
-	srv = Sprite_Manager::Load(imgFile);
-	
-}
-
-void Sprite::UpdateWorld()
-{
-
-	//D3DXMATRIX W, S, R, T;
-
-	//D3DXMatrixScaling(&S, scale.x, scale.y , scale.z);
-	//D3DXMatrixRotationYawPitchRoll(&R, rotator.y, rotator.x, rotator.z);
-	//D3DXMatrixTranslation(&T, position.x, position.y, position.z);
-	//W = S * R * T;
-	////W = S * T;
-	//world = W; // world  업데이트
-	//shader->AsMatrix("World")->SetMatrix(W);
-
-	//if (rotator.y >= 3.14f)
-	//	W = S * T;
-	//BoundShader->AsMatrix("World")->SetMatrix(W);
-}
-void Sprite::ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P)
-{
-	/*shader->AsMatrix("View")->SetMatrix(V);
-	shader->AsMatrix("Projection")->SetMatrix(P);
-
-	BoundShader->AsMatrix("View")->SetMatrix(V);
-	BoundShader->AsMatrix("Projection")->SetMatrix(P);*/
 }
 
 
-void Sprite::Render()
-{
-	//UINT stride = sizeof(Vertex);
-	//UINT offset = 0;
-
-	//DeviceContext->IASetVertexBuffers(0, 1, &vertexBuffer, &stride, &offset);
-	//DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-
-	//shader->Draw(0, 0, 6);
-
-	//CheckFalse(bDrawBound);
-
-	//stride = sizeof(BoundVertex);
-	//offset = 0;
-
-	//DeviceContext->IASetVertexBuffers(0, 1, &BoundBuffer, &stride, &offset);
-	//DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP);
-
-	//BoundShader->Draw(0, 0, 5);
-
-	
-}
 
 
 
 map<wstring, Sprite_Manager::Sprite_Desc> Sprite_Manager::m;
+map < wstring, vector<ID3D11Buffer*>> Sprite_Manager::m_buffer;
+map < wstring, vector<vector<ID3D11Buffer*>>> Sprite_Manager::m_buffer_vec;
 
 ID3D11ShaderResourceView* Sprite_Manager::Load(wstring imgFile)
 {
@@ -302,6 +251,43 @@ ID3D11ShaderResourceView* Sprite_Manager::Load(wstring imgFile)
 	}
 	return m[imgFile].srv;
 }
+vector<ID3D11Buffer*> Sprite_Manager::LoadBuffer(wstring imgfile)
+{
+	UINT cnt = m_buffer.count(imgfile);
+	if (cnt != 0)
+		return m_buffer[imgfile];
+
+	return vector<ID3D11Buffer*>(); 
+}
+
+vector<vector<ID3D11Buffer*>> Sprite_Manager::LoadBufferVector(wstring imgfile)
+{
+	UINT cnt = m_buffer_vec.count(imgfile);
+	if (cnt != 0)
+		return m_buffer_vec[imgfile];
+
+	return vector<vector<ID3D11Buffer*>>();
+}
+
+void Sprite_Manager::StoreBuffer(wstring imgfile, vector<ID3D11Buffer*> buffer_vec)
+{
+	UINT cnt = m_buffer.count(imgfile);
+	if (cnt == 0)
+	{
+		m_buffer[imgfile] = buffer_vec;
+	}
+}
+
+void Sprite_Manager::StoreBufferVector(wstring imgfile, vector<vector<ID3D11Buffer*>> buffer_vec)
+{
+	UINT cnt = m_buffer_vec.count(imgfile);
+	if (cnt == 0)
+	{
+		m_buffer_vec[imgfile] = buffer_vec;
+	}
+}
+
+
 
 void Sprite_Manager::ReMove(wstring imgFile)
 {
@@ -313,3 +299,5 @@ void Sprite_Manager::ReMove(wstring imgFile)
 		SAFE_RELEASE(m[imgFile].srv);
 	}
 }
+
+

--- a/Digimon_Game_Portfolio/Sprite.h
+++ b/Digimon_Game_Portfolio/Sprite.h
@@ -7,19 +7,16 @@ public:
 	Sprite(wstring imgFile, wstring shaderFile = Texture_Shader);
 	Sprite(wstring imgFile, float End_X, float End_Y, wstring shaderFile = Texture_Shader);
 	Sprite(wstring imgFile, float start_X, float start_Y, float End_X, float End_Y, wstring shaderFile = Texture_Shader);
-
-
-	Sprite(vector<ID3D11ShaderResourceView*>& ownerShader, vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, wstring shaderFile = Texture_Shader);
-	Sprite(vector<ID3D11ShaderResourceView*>& ownerShader, vector<ID3D11Buffer*>& ownerbuffer,wstring imgFile, float start_X, float start_Y, float End_X, float End_Y, wstring shaderFile = Texture_Shader);
 	
+	Sprite(vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, wstring shaderFile = Texture_Shader);
+	Sprite(vector<ID3D11Buffer*>& ownerbuffer, wstring imgFile, float start_X, float start_Y, float End_X, float End_Y, wstring shaderFile = Texture_Shader);
+
 	virtual void CreateBuffer(wstring imgFile, wstring shaderFile) ;
 
 
-	void UpdateWorld();
-	void ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P);
-	void Render();
-
-	//virtual Hit CheckRayCollision(Ray& ray) { return Hit(); }// ray 이벤트 미완성
+	//void UpdateWorld();
+	//void ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P);
+	//void Render();
 
 	
 	void Init_Sprite(wstring imgFile, float start_X, float start_Y, float End_X, float End_Y); // startX ,startY EndX, EndY
@@ -69,8 +66,15 @@ class Sprite_Manager
 	friend class Sprite;
 public:
 	static ID3D11ShaderResourceView* Load(wstring img);
-	static void ReMove(wstring img);
+	static vector<ID3D11Buffer*> LoadBuffer(wstring img);
+	static vector<vector<ID3D11Buffer*>> LoadBufferVector(wstring img);
+	
+	static void StoreBuffer(wstring imgfile, vector<ID3D11Buffer*> buffer_vec); //총알같이 State가 없을떄
+	static void StoreBufferVector(wstring imgfile, vector<vector<ID3D11Buffer*>> buffer_vec);
+	
 
+	static void ReMove(wstring img);
+	
 	struct Sprite_Desc
 	{
 	public:
@@ -78,4 +82,6 @@ public:
 		ID3D11ShaderResourceView* srv = nullptr;
 	};
 	static map<wstring, Sprite_Desc> m;
+	static map<wstring, vector<ID3D11Buffer*>> m_buffer;
+	static map<wstring, vector<vector<ID3D11Buffer*>>> m_buffer_vec;
 };

--- a/Digimon_Game_Portfolio/Stages/Stage.cpp
+++ b/Digimon_Game_Portfolio/Stages/Stage.cpp
@@ -50,10 +50,12 @@ void Stage::CreateShaderAndBuffer(vector<wstring> imagefiles, vector<wstring> sh
 	position.reserve(imagefiles.size());
 	scale.reserve(imagefiles.size());
 	rotator.reserve(imagefiles.size());
-
+	srv_vec.resize(imagefiles.size());
+	
 	for (int i=0; i < imagefiles.size(); i++)
 	{
-		make_unique<Sprite>(srv_vec, buffer_vec, imagefiles[i], shaderfiles[i]);
+		srv_vec[i] = Sprite_Manager::Load(imagefiles[i]);
+		make_unique<Sprite>( buffer_vec, imagefiles[i], shaderfiles[i]);
 
 		shader_vec.push_back(make_unique<Shader>(shaderfiles[i]));
 		position.push_back({ 0,0,0 });

--- a/Digimon_Game_Portfolio/Stages/Stage_01.h
+++ b/Digimon_Game_Portfolio/Stages/Stage_01.h
@@ -40,8 +40,13 @@ private:
 
 
 	bool bclear =false;
-
-	// ∏Æ∆—≈‰∏µ 
+	//∏Æ∆—≈‰∏µ
 	vector<unique_ptr<class Reward_Card>> reward;
+
+
+
+	//∏Æ∆—≈‰∏µ
+
+
 };
 

--- a/Digimon_Game_Portfolio/UI/Bottom_UI.cpp
+++ b/Digimon_Game_Portfolio/UI/Bottom_UI.cpp
@@ -26,9 +26,9 @@ void Bottom_UI::Update()
 
 void Bottom_UI::Render()
 {
-	sprite->Render();
+	//sprite->Render();
 	CheckFalse(bvictory);
-	victory->Render();
+	//victory->Render();
 }
 
 void Bottom_UI::ViewProjection(D3DXMATRIX& V, D3DXMATRIX& P)

--- a/Digimon_Game_Portfolio/imgui.ini
+++ b/Digimon_Game_Portfolio/imgui.ini
@@ -1,5 +1,5 @@
 [Window][Debug##Default]
 Pos=544,42
 Size=400,400
-Collapsed=0
+Collapsed=1
 

--- a/_Shaders/07_Texture.fx
+++ b/_Shaders/07_Texture.fx
@@ -47,7 +47,7 @@ SamplerState Sampler;
 float4 PS(VertexOutput input) : SV_TARGET0
 {
     float4 color = Map.Sample(Sampler, input.Uv);
-    //color.a = 0.7f; 우연히 발견  어둡기 조절 이거로하면될듯
+    //color.a = 0.7f;  어둡기 조절 이거로하면될듯
     return color;
 
 }


### PR DESCRIPTION
경량패턴 적용 완료 .
단, 카드에서 생성될 때 Digimon을 동적할당 하는것은 고쳐야함.
다음에
DigimonPool 을 따로 만들고 Digimon에 buffer와 srv 갱신하는 기능 만들어서 구현하기.